### PR TITLE
Serialization and deserialization of nested enums would not match.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcs"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Diem <opensource@diem.com>"]
 description = "Binary Canonical Serialization (BCS)"
 repository = "https://github.com/diem/bcs"

--- a/src/de.rs
+++ b/src/de.rs
@@ -369,7 +369,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self.leave_named_container();
         r
     }
-
+    #[allow(clippy::needless_borrow)]
     fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
@@ -377,14 +377,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         let len = self.parse_length()?;
         visitor.visit_seq(SeqDeserializer::new(&mut self, len))
     }
-
+    #[allow(clippy::needless_borrow)]
     fn deserialize_tuple<V>(mut self, len: usize, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         visitor.visit_seq(SeqDeserializer::new(&mut self, len))
     }
-
+    #[allow(clippy::needless_borrow)]
     fn deserialize_tuple_struct<V>(
         mut self,
         name: &'static str,
@@ -399,7 +399,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self.leave_named_container();
         r
     }
-
+    #[allow(clippy::needless_borrow)]
     fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
@@ -407,7 +407,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         let len = self.parse_length()?;
         visitor.visit_map(MapDeserializer::new(&mut self, len))
     }
-
+    #[allow(clippy::needless_borrow)]
     fn deserialize_struct<V>(
         mut self,
         name: &'static str,
@@ -464,7 +464,7 @@ struct SeqDeserializer<'a, 'de: 'a> {
     de: &'a mut Deserializer<'de>,
     remaining: usize,
 }
-
+#[allow(clippy::needless_borrow)]
 impl<'a, 'de> SeqDeserializer<'a, 'de> {
     fn new(de: &'a mut Deserializer<'de>, remaining: usize) -> Self {
         Self { de, remaining }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use thiserror::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
-
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum Error {
     #[error("unexpected end of input")]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -260,10 +260,11 @@ where
 
     fn serialize_unit_variant(
         mut self,
-        _name: &'static str,
+        name: &'static str,
         variant_index: u32,
         _variant: &'static str,
     ) -> Result<()> {
+        self.enter_named_container(name)?;
         self.output_variant_index(variant_index)
     }
 


### PR DESCRIPTION
### **MOTIVATION**

There was a small bug where the serialization and deserialization of nested
enums would not match, so a fork created of diem/bcs in the [Zefchain org](https://github.com/zefchain/bcs/commit/99dd7a39a2ee8753dc7a79280eb80f641d6fbb0e), applied the fix, and
then released v0.1.4 of bcs to crates.io

The fixes done in Zefchain branch, are incorporated in forked repo of [Diem bcs](https://github.com/vikalpacn/bcs/commit/4b6129db12b0e2ad72e02c58a1dfee3294e4bc3b) and then merged with diem/diem.

-fixes are applied in diem bcs version 0.1.3 regarding the matching of serialization and de-serialization
of Nested enums and updating it to version 0.1.4.

-Then, building diem bcs version 0.1.4.

-referring diem bcs version 0.1.4 to diem code base.


### **DESCRIPTION**

The fixes done in Zefchain branch, are incorporated in forked repo of Diem bcs and then merged with diem/diem.

1. First step is to apply the fixes in diem bcs version 0.1.3 regarding the matching of serialization and de-serialization
 of Nested enums and updating it to version 0.1.4.

2. Then, building diem bcs version 0.1.4 and performing unit testing for **fn test_recursion_limit()** :
  - _cargo test --package bcs --test serde -- test_recursion_limit --exact --nocapture_
   
3. After successful build and testing, referring diem bcs version 0.1.4 to diem code base.

4. To refer, first making changes in bcs of **cargo.toml** file of a single module (Applying path of diem bcs- )
     * then,   
     1. Build- _cargo build_
     2. Test- _cargo test -p "Name of a particular module"_
	 
5.After successful build of a single module, further applying the changes in all the modules by giving address of diem bcs in cargo.toml file.

6. Then, 
 - cargo build diem-  _cargo build_
 - _Smoke test- cargo x test --package smoke-test -- --test-threads 1_
 - _integration test- cargo xtest -p jsonrpc-integration-tests_