### PR TITLE
Update Cargo.toml for thiserror to version 1.0.37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-thiserror = "1.0.24"
+thiserror = "1.0.37"
 serde = { version = "1.0.117", features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
### Motivation
Thiserror package version conflicts with diem transaction builder, so upgrade the version for the same
### Testplan
CI/CD existing test will cover above changes