### PR TITLE
Expose `Serializer` and `Deserializer` directly

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -54,7 +54,7 @@ where
 }
 
 /// Deserialization implementation for BCS
-struct Deserializer<'de> {
+pub struct Deserializer<'de> {
     input: &'de [u8],
     max_remaining_depth: usize,
 }
@@ -62,7 +62,7 @@ struct Deserializer<'de> {
 impl<'de> Deserializer<'de> {
     /// Creates a new `Deserializer` which will be deserializing the provided
     /// input.
-    fn new(input: &'de [u8], max_remaining_depth: usize) -> Self {
+    pub fn new(input: &'de [u8], max_remaining_depth: usize) -> Self {
         Deserializer {
             input,
             max_remaining_depth,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,6 @@ pub const MAX_SEQUENCE_LENGTH: usize = (1 << 31) - 1;
 /// Maximal allowed depth of BCS data, counting only structs and enums.
 pub const MAX_CONTAINER_DEPTH: usize = 500;
 
-pub use de::{from_bytes, from_bytes_seed};
+pub use de::{Deserializer, from_bytes, from_bytes_seed};
 pub use error::{Error, Result};
-pub use ser::{is_human_readable, serialize_into, serialized_size, to_bytes};
+pub use ser::{Serializer, is_human_readable, serialize_into, serialized_size, to_bytes};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -98,7 +98,7 @@ pub fn is_human_readable() -> bool {
 }
 
 /// Serialization implementation for BCS
-struct Serializer<'a, W: ?Sized> {
+pub struct Serializer<'a, W: ?Sized> {
     output: &'a mut W,
     max_remaining_depth: usize,
 }
@@ -108,7 +108,7 @@ where
     W: ?Sized + std::io::Write,
 {
     /// Creates a new `Serializer` which will emit BCS.
-    fn new(output: &'a mut W, max_remaining_depth: usize) -> Self {
+    pub fn new(output: &'a mut W, max_remaining_depth: usize) -> Self {
         Self {
             output,
             max_remaining_depth,
@@ -437,8 +437,7 @@ where
     }
 }
 
-#[doc(hidden)]
-struct MapSerializer<'a, W: ?Sized> {
+pub struct MapSerializer<'a, W: ?Sized> {
     serializer: Serializer<'a, W>,
     entries: Vec<(Vec<u8>, Vec<u8>)>,
     next_key: Option<Vec<u8>>,


### PR DESCRIPTION
Allows external projects to plug BCS into libraries that expect a `serde` `Serializer` or `Deserializer` implementation.