### PR TITLE
remove serde derive from dependency and bump criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,14 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+serde = "1.0.117"
 thiserror = "1.0.37"
-serde = { version = "1.0.117", features = ["derive"] }
 
 [dev-dependencies]
-criterion = "0.3.3"
 proptest = "0.10.1"
-proptest-derive = "0.2.0"
+criterion = "0.7.0"
+proptest-derive = "0.7.0"
+serde = { version = "1.0.117", features = ["derive"] }
 
 [[bench]]
 name = "bcs_bench"


### PR DESCRIPTION
The derive feature of serde is only required as a dev-depdendency. Making the derive feature a dependency of the crate means that anything that depends on this crate has to pull in and compile syn, quote, proc_macro2 etc. 

Additionally running tests yields the following warnings:

```
warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
  --> tests/serde.rs:61:10
   |
61 | #[derive(Arbitrary, Debug, Deserialize, Serialize, PartialEq)]
   |          ^--------
   |          |
   |          `Arbitrary` is not local
   |          move the `impl` block outside of this constant `_IMPL_ARBITRARY_FOR_S`
62 | struct S {
   |        - `S` is not local
   |
   = note: the derive macro `Arbitrary` defines the non-local `impl`, and may need to be changed
   = note: the derive macro `Arbitrary` may come from an old version of the `proptest_derive` crate, try updating your dependency with `cargo update -p proptest_derive`
   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
   = note: `#[warn(non_local_definitions)]` on by default
   = note: this warning originates in the derive macro `Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
```

this is fixed simply by upgrading the proptest dependency which this crate also does.